### PR TITLE
chore!: drop support for node.js 4.x and 9.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,8 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node4
       - node6
       - node8
-      - node9
       - node10
       - node11
       - publish_npm:
@@ -34,10 +32,6 @@ workflows:
               only: /^v[\d.]+$/
 
 jobs:
-  node4:
-    docker:
-      - image: node:4
-    <<: *unit_tests
   node6:
     docker:
       - image: node:6
@@ -45,10 +39,6 @@ jobs:
   node8:
     docker:
       - image: node:8
-    <<: *unit_tests
-  node9:
-    docker:
-      - image: node:9
     <<: *unit_tests
   node10:
     docker:

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "js-green-licenses": "^0.5.0",
     "jshint": "^2.9.4",
     "mocha": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: This change drops explicit support for Node.js 4.x and 9.x.