### PR TITLE
build!: drop support for Node 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,11 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node6
       - node8
       - node10
       - node11
       - publish_npm:
           requires:
-            - node6
             - node8
             - node10
             - node11
@@ -32,10 +30,6 @@ workflows:
               only: /^v[\d.]+$/
 
 jobs:
-  node6:
-    docker:
-      - image: node:6
-    <<: *unit_tests
   node8:
     docker:
       - image: node:8

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "typescript": "~3.4.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Stop supporting Node 6 as it reaches EOL.