### PR TITLE
Update to non-deprecated uuid import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,13 @@
  */
 
 const d64 = require('d64');
-import * as uuid from 'uuid';
+const uuid = require('uuid/v4');
 
 export class EventId {
   b: Uint8Array;
   constructor() {
     this.b = new Uint8Array(24);
-    uuid.v4(null, this.b, 8);
+    uuid(null, this.b, 8);
   }
 
   new() {


### PR DESCRIPTION
This PR just updates the import statement for the UUID library to conform to the new standard as indicated [here](https://github.com/kelektiv/node-uuid#readme):

>Deprecation warning: The use of require('uuid') is deprecated and will not be supported after version 3.x of this module. Instead, use require('uuid/[v1|v3|v4|v5]')