### PR TITLE
build: use release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+releaseType: node
+handleGHRelease: true


### PR DESCRIPTION
I would love to cut a release, but would really rather not use the previous model :) The release-please github app is installed on the repo now, and I am blindly copying this config from yargs.  

@bcoe .... what's actually responsible from running `npm publish`?  Should we keep that in the `.circleci` config, triggered on tag create?